### PR TITLE
Bugfix: fasta input parsing

### DIFF
--- a/Tests/test_cds_parser.R
+++ b/Tests/test_cds_parser.R
@@ -82,12 +82,3 @@ test_that("extract_cds should not return sequences with internal stop codons", {
 test_that("extract_cds should allow sequences ending in a stop codon", {
 	expect_error(extract_cds(SEQUENCE, VALID_START, TRAILING_STOP), NA) # Expect no error
 })
-
-
-test_that("extract_cds should strip trailing stop codon", {
-	expectedSeq <- SEQUENCE[VALID_START:VALID_STOP]
-	returnedSeq <- extract_cds(SEQUENCE, VALID_START, TRAILING_STOP)
-	returnedSeq <- as.character(returnedSeq)
-	
-	expect_equal(returnedSeq, expectedSeq)
-})

--- a/Utils/cds_parser.R
+++ b/Utils/cds_parser.R
@@ -12,7 +12,7 @@ check_cds <- function(sequence) {
 	
 	translation <- seqinr::getTrans(sequence)
 	
-	if ("*" %in% translation)
+	if ("*" %in% translation[1:(length(translation) - 1)])
 		stop("Extracted CDS contained an internal stop codon.")
 }
 
@@ -51,13 +51,6 @@ extract_cds_internal <- function(sequence, start_coordinate, stop_coordinate, al
 	if (reverse_complement) {
 		cds <- rev(seqinr::comp(cds))
 	}
-	
-	# Strip trailing stop codon
-	# - Give flexibility in how coordinates are specified
-	lastcodon <- paste(cds[(length(cds) - 2):length(cds)], collapse = "")
-	
-	if (tolower(lastcodon) %in% c("taa", "tag", "tga"))
-		cds <- cds[1:(length(cds) - 3)]
 	
 	# Check cds for validity before returning
 	check_cds(cds)


### PR DESCRIPTION
Optional fasta input format used only the last ORF on each sequence for prediction